### PR TITLE
Dynamic names

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,29 @@ Mustache.render(template, view, {
 });
 ```
 
+Partials can have dynamic names, which begin with `*`.  In this case, a value is read from the context and the partial with that value is used.
+
+For example, this template and partial:
+
+    base.mustache:
+    <h2>Message of the Day</h2>
+    {{> *dayOfWeek}}
+
+    thursday.mustache:
+    <span>This must be Thursday. I never could get the hang of Thursdays.</span>
+
+When loaded with the context:
+```json
+{
+  "dayOfWeek": "thursday"
+}
+```
+will be expanded to:
+```html
+    <h2>Message of the Day</h2>
+    <span>This must be Thursday. I never could get the hang of Thursdays.</span>
+```
+
 ### Custom Delimiters
 
 Custom delimiters can be used in place of `{{` and `}}` by setting the new values in JavaScript or in templates.

--- a/mustache.js
+++ b/mustache.js
@@ -641,7 +641,7 @@ Writer.prototype.renderPartial = function renderPartial (token, context, partial
   var tags = this.getConfigTags(config);
 
   // Partial names beginning with an asterix are treated as a dynamic name
-  if (token[1].trim().startsWith('*')) {
+  if (token[1].trim().substring(0, 1) === '*') {
     token[1] = context.lookup(token[1].trim().substring(1).trim());
   }
   var value = isFunction(partials) ? partials(token[1]) : partials[token[1]];

--- a/mustache.js
+++ b/mustache.js
@@ -640,6 +640,10 @@ Writer.prototype.renderPartial = function renderPartial (token, context, partial
   if (!partials) return;
   var tags = this.getConfigTags(config);
 
+  // Partial names beginning with an asterix are treated as a dynamic name
+  if (token[1].trim().startsWith('*')) {
+    token[1] = context.lookup(token[1].trim().substring(1).trim());
+  }
   var value = isFunction(partials) ? partials(token[1]) : partials[token[1]];
   if (value != null) {
     var lineHasNonSpace = token[6];

--- a/test/mustache-spec-test.js
+++ b/test/mustache-spec-test.js
@@ -14,12 +14,43 @@ var skipTests = {
   inverted: [
     'Standalone Without Newline'
   ],
+  interpolation: [
+    'Dotted Names - Context Precedence'
+  ],
   partials: [
     'Standalone Without Previous Line',
     'Standalone Without Newline'
   ],
   sections: [
     'Standalone Without Newline'
+  ],
+  '~inheritance': [
+    'Default',
+    'Variable',
+    'Triple Mustache',
+    'Sections',
+    'Negative Sections',
+    'Mustache Injection',
+    'Inherit',
+    'Overridden content',
+    'Data does not override block',
+    'Data does not override block default',
+    'Overridden parent',
+    'Two overridden parents',
+    'Override parent with newlines',
+    'Inherit indentation',
+    'Only one override',
+    'Parent template',
+    'Recursion',
+    'Multi-level inheritance',
+    'Multi-level inheritance, no sub child',
+    'Text inside parent',
+    'Block scope',
+    'Standalone parent',
+    'Standalone block',
+    'Block reindentation',
+    'Intrinsic indentation',
+    'Nested block reindentation'
   ],
   '~lambdas': [
     'Interpolation',


### PR DESCRIPTION
The mustache spec now includes an optional part of the spec for using dynamic names in partials: https://github.com/mustache/spec/blob/master/specs/~dynamic-names.yml

I've not contributed to any mustache projects before, so I've tried to keep my code change as concise and self-contained as possible, whilst getting all the relevant tests in the spec to pass.
(If you'd prefer something more verbose to aid code readability, I'm happy to adjust)